### PR TITLE
remove https only limitation

### DIFF
--- a/lib/Crawler.js
+++ b/lib/Crawler.js
@@ -31,10 +31,6 @@ function validateUrl(crawlerSeedUrl) {
 
   // Strip off trailing colon
   urlProtocol = crawlerSeedUrl.protocol.slice(0, -1);
-
-  if (urlProtocol !== 'https') {
-    throw new Error('Spider only support https protocol.');
-  }
 }
 
 /**
@@ -45,11 +41,19 @@ function validateUrl(crawlerSeedUrl) {
  */
 function setConfigRootUrl(config, crawlerSeedUrl) {
   let portString = '';
+  let protocolString = '';
 
   if (crawlerSeedUrl.port) {
     portString = `:${crawlerSeedUrl.port}`;
   }
-  config.rootUrl = `https://${crawlerSeedUrl.hostname}${portString}`;
+
+  if (crawlerSeedUrl.protocol) {
+    protocolString = crawlerSeedUrl.protocol;
+  } else {
+    protocolString = 'https';
+  }
+
+  config.rootUrl = `${protocolString}://${crawlerSeedUrl.hostname}${portString}`;
   cursor.reset().write(`Set config.rootUrl to ${config.rootUrl}\n`);
 }
 

--- a/lib/Crawler.js
+++ b/lib/Crawler.js
@@ -41,16 +41,10 @@ function validateUrl(crawlerSeedUrl) {
  */
 function setConfigRootUrl(config, crawlerSeedUrl) {
   let portString = '';
-  let protocolString = '';
+  let protocolString = crawlerSeedUrl.protocol || 'https';
 
   if (crawlerSeedUrl.port) {
     portString = `:${crawlerSeedUrl.port}`;
-  }
-
-  if (crawlerSeedUrl.protocol) {
-    protocolString = crawlerSeedUrl.protocol;
-  } else {
-    protocolString = 'https';
   }
 
   config.rootUrl = `${protocolString}://${crawlerSeedUrl.hostname}${portString}`;


### PR DESCRIPTION
### Problem

The BT Docs development environment doesn't use ssl for localhost connections. This means we are unable to use the spidersuite for either local or CI testing.

### Solution

Remove the https protocol requirement and assume the protocol of the specified url. Default to https.

@braebot 
