### PR TITLE
limit ignore message to single instance

### DIFF
--- a/lib/Crawler.js
+++ b/lib/Crawler.js
@@ -310,7 +310,6 @@ module.exports = function (myUrl, config, verbose) {
       initTls(config);
 
       crawler = new Crawler(myUrl);
-      crawler.ignored = [];
 
       initAdditionalPaths(config, crawler);
       initSpool(config, crawler);

--- a/lib/Crawler.js
+++ b/lib/Crawler.js
@@ -310,6 +310,7 @@ module.exports = function (myUrl, config, verbose) {
       initTls(config);
 
       crawler = new Crawler(myUrl);
+      crawler.ignored = [];
 
       initAdditionalPaths(config, crawler);
       initSpool(config, crawler);

--- a/lib/Logger.js
+++ b/lib/Logger.js
@@ -173,7 +173,7 @@ module.exports = function (crawler, verbose) {
     logIgnore(parsedURL) {
       const url = parsedURL.url;
 
-      if (verbose && crawler.ignored.indexOf(url) === -1) {
+      if (verbose && this.ignored.indexOf(url) === -1) {
         clearLine();
         cursor
           .grey()
@@ -183,7 +183,6 @@ module.exports = function (crawler, verbose) {
           .write('\n');
       }
       this.ignored.push(url);
-      crawler.ignored.push(url);
     },
 
     /**

--- a/lib/Logger.js
+++ b/lib/Logger.js
@@ -173,7 +173,7 @@ module.exports = function (crawler, verbose) {
     logIgnore(parsedURL) {
       const url = parsedURL.url;
 
-      if (verbose) {
+      if (verbose && crawler.ignored.indexOf(url) === -1) {
         clearLine();
         cursor
           .grey()
@@ -183,6 +183,7 @@ module.exports = function (crawler, verbose) {
           .write('\n');
       }
       this.ignored.push(url);
+      crawler.ignored.push(url);
     },
 
     /**


### PR DESCRIPTION
### Problem

Whenever we find an ignored url on a new page, we log it out. that's excessive, even for a verbose mode! For more info, check out the [issue](https://github.com/braintree/spidersuite/issues/1)

### Solution

Track crawler-wide ignored files so that if we find an ignored url twice, we only log it once. 

### How do you know this works?

[original.txt](https://github.com/braintree/spidersuite/files/1297507/original.txt)
[fixed.txt](https://github.com/braintree/spidersuite/files/1297508/fixed.txt)

look at em yourself!

or look at this:
```
jellenberger$ cat original.txt | grep "_ https://xoom.com/" | wc -l
      18
jellenberger$ ^original^fixed
cat fixed.txt | grep "_ https://xoom.com/" | wc -l
       1
```

@braebot 